### PR TITLE
Fixed compiler warnings

### DIFF
--- a/src/DeviceSource.cpp
+++ b/src/DeviceSource.cpp
@@ -153,7 +153,7 @@ void V4L2DeviceSource::deliverFrame()
 			m_captureQueue.pop_front();
 	
 			m_out.notify(curTime.tv_sec, frame->m_size);
-			if (frame->m_size > fMaxSize) 
+			if (frame->m_size > (int) fMaxSize) 
 			{
 				fFrameSize = fMaxSize;
 				fNumTruncatedBytes = frame->m_size - fMaxSize;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -395,8 +395,8 @@ int main(int argc, char** argv)
 	unsigned int hlsSegment = 0;
 	const char* realm = NULL;
 	std::list<std::string> userPasswordList;
-	int audioFreq = 44100;
-	int audioNbChannels = 2;
+	//int audioFreq = 44100;
+	//int audioNbChannels = 2;
 #ifdef HAVE_ALSA	
 	std::list<snd_pcm_format_t> audioFmtList;
 	snd_pcm_format_t audioFmt = SND_PCM_FORMAT_UNKNOWN;


### PR DESCRIPTION
Fixed comiler warnings by adding a type cast and commenting out a couple of unused variables.