### PR TITLE
Update README.md default alsa capture is S16_LE

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Usage
 		 ALSA options :
 		 -A freq    : ALSA capture frequency and channel (default 44100)
 		 -C channels: ALSA capture channels (default 2)
-		 -a fmt     : ALSA capture audio format (default S16_BE)
+		 -a fmt     : ALSA capture audio format (default S16_LE)
 		 
 		 device   : V4L2 capture device and/or ALSA device (default /dev/video0)
 


### PR DESCRIPTION
Although the default RTP payload stream is S16_BE the "v4l2rtspserver" defaults to S16_LE alsa capture while not specifying any format shown with the following use cases in this post.  See specifically `./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicb #noise, default is LE>BE!!!`.

This can be a bug in code or mistake in documentation you may choose what/where to fix :-).

Reproducable steps:
Add the following code to your `~/.asoundrc` that's in your `/home/pi` folder, `/etc/asound.conf` is not used in my example!
```
pcm.virtmica {
    type file
    format "raw"
    file "/dev/null"
    infile "/home/pi/music16le.raw"
    slave.pcm "default"
}
pcm.virtmicb {
    type file
    format "raw"
    file "/dev/null"
    infile "/home/pi/music16be.raw"
    slave.pcm "default"
}
pcm.virtmicc {
    type file
    format "raw"
    file "/dev/null"
    infile "/home/pi/music32le.raw"
    slave.pcm "default"
}
pcm.virtmicd {
    type file
    format "raw"
    file "/dev/null"
    infile "/home/pi/music32be.raw"
    slave.pcm "default"
}
```
Create some raw pcm music sources with `ffmpeg`, which I use a minute(s) long mp3 music file for (16bit 44100Hz stereo) in my example. Use filenames that resemble code above and use long enough samples as in minutes not seconds, since as soon as the v4l2rtspserver is started the music file starts playing and will not loop!

```
sudo apt-get install ffmpeg
ffmpeg -i music.mp3 -f s16le -acodec pcm_s16le /home/pi/music16le.raw
ffmpeg -i music.mp3 -f s16be -acodec pcm_s16be /home/pi/music16be.raw
ffmpeg -i music.mp3 -f s32le -acodec pcm_s32le /home/pi/music32le.raw
ffmpeg -i music.mp3 -f s32be -acodec pcm_s32be /home/pi/music32be.raw
```
Test `v4l2rtspserver` (before commit 41589c8) with the virtual alsa devices and sample files you just made:
```
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmica #you hear music
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmica -a S16_LE #you hear music
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmica -a S16_BE #noise

./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicb #noise, default is LE>BE!!!
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicb -a S16_LE #noise
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicb -a S16_BE #you hear music

./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicc #slow/offpitch music :-)
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicc -a S32_LE #recognizable interupted music with gaps
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicc -a S32_BE #noise with gaps

./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicd #noise
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicd -a S32_LE #noise with gaps
./v4l2rtspserver -F 25 -W 1280 -H 720 -P 8555 /dev/video0,virtmicd -a S32_BE #recognizable interupted music with gaps

```