### PR TITLE
Add a few missing headers

### DIFF
--- a/inc/DeviceSource.h
+++ b/inc/DeviceSource.h
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <iomanip>
 
+#include <pthread.h>
+
 // live555
 #include <liveMedia.hh>
 

--- a/inc/MemoryBufferSink.h
+++ b/inc/MemoryBufferSink.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 #include "MediaSink.hh"
 


### PR DESCRIPTION
Helps to compile with alternative c++ libraries.

A lot more work needs to be done though. I'm getting a lot of linking errors when compiling with uclibc++. Log: https://gist.github.com/neheb/572dbf37f468c284f649b03f729d1e83