### PR TITLE
Use ubuntu:18.04 for builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian as builder
+FROM ubuntu:18.04 as builder
 LABEL maintainer michel.promonet@free.fr
 WORKDIR /v4l2rtspserver
 COPY . /v4l2rtspserver


### PR DESCRIPTION
The debian and ubuntu:18.04 images use different glibc versions, which makes the binary built in debian incompatible with the image it's copied to:

```
$ docker run -it mpromonet/v4l2rtspserver -h
/usr/local/bin/v4l2rtspserver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/bin/v4l2rtspserver)
```

Using the same image for both stages fixes the issue. Final size is the same, 65.8 MB. Successfully streamed an H264 webcam using the built container.