### PR TITLE
Update main.cpp - change ourIPAddress method

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -523,7 +523,7 @@ int main(int argc, char** argv)
 				nbSource += rtspServer.addSession(baseUrl+tsurl, subSession);
 				
 				struct in_addr ip;
-				ip.s_addr = ourIPAddress(*rtspServer.env());
+				ip.s_addr = ourIPv4Address(*rtspServer.env());
 				LOG(NOTICE) << "HLS       http://" << inet_ntoa(ip) << ":" << rtspPort << "/" << baseUrl+tsurl << ".m3u8";
 				LOG(NOTICE) << "MPEG-DASH http://" << inet_ntoa(ip) << ":" << rtspPort << "/" << baseUrl+tsurl << ".mpd";
 			}


### PR DESCRIPTION
Hello,

Due to a change on 29/01 in the code of live555, the call to method "ourIPAddress" needs to be updated to "ourIPv4Address".

Update from live555:
2021.01.29:
- Renamed the 'groupsock' function "ourIPAddress()" to "ourIPv4Address()".
  (We also define a function "ourIPv6Address()", though for now this just returns a null
   IPv6 address.)
source: http://live555.com/liveMedia/public/changelog.txt

I tried to compile this code and I had issue during the make. This tiny change made the compilation successful.

This is my first pull request on github, I hope I did it properly and this helps.