### PR TITLE
Update arm64 Dockerfile to build audio support

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -6,7 +6,7 @@ COPY . /v4l2rtspserver
 ARG ARCH=arm64
 
 RUN apt-get update \
-        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates xz-utils cmake make pkg-config git wget gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+        && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates xz-utils cmake make pkg-config git wget gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libasound2-dev \
         && cmake -DCMAKE_SYSTEM_PROCESSOR=${ARCH} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY . \
 	&& make install \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/
@@ -17,6 +17,9 @@ FROM arm64v8/ubuntu:20.04
 WORKDIR /usr/local/share/v4l2rtspserver
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/share/v4l2rtspserver/ /usr/local/share/v4l2rtspserver/
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates libasound2 libssl1.1 && apt-get clean && rm -rf /var/lib/apt/lists/
 
 ENTRYPOINT [ "/usr/local/bin/v4l2rtspserver" ]
 CMD [ "-S" ]


### PR DESCRIPTION
I would like to update the arm64 Dockerfile to support alsa.

## Description

This is to update the arm64 Dockerfile to build alsa support.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/mpromonet/v4l2rtspserver/issues/295

## Motivation and Context
I use this project on some of my arm machines and rather than rebuilding the containers locally, I think it would be beneficial to have the upstream arm64 images support alsa.

<!--- Why is this change required? What problem does it solve? -->
It prevents users from rebuilding the arm64 docker images to support alsa.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
