### PR TITLE
[BUGFIX #299] Do not exit thread upon EAGAIN error when fetching frames

### DIFF
--- a/src/V4L2DeviceSource.cpp
+++ b/src/V4L2DeviceSource.cpp
@@ -108,8 +108,15 @@ void* V4L2DeviceSource::thread()
 				LOG(DEBUG) << "waitingFrame\tdelay:" << (1000-(tv.tv_usec/1000)) << "ms"; 
 				if (this->getNextFrame() <= 0)
 				{
-					LOG(ERROR) << "error:" << strerror(errno); 						
-					stop=1;
+					if (errno == EAGAIN)
+					{
+						LOG(NOTICE) << "Retrying getNextFrame";
+					}
+					else
+					{
+						LOG(ERROR) << "error:" << strerror(errno);
+						stop=1;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
To use the latest Camera v3 from Raspberry Pi, we need to use libcamerify which is a V4L2 compatibility layer preload.

libcamerify -d v4l2rtspserver

I don't know if it is due to libcamerify, but sometimes the camera seems to be temporary unavailable:

[NOTICE] /home/azsde/v4l2rtspserver/src/V4L2DeviceSource.cpp:203
        V4L2DeviceSource::getNextFrame errno:11 Resource temporarily unavailable
[ERROR] /home/azsde/v4l2rtspserver/src/V4L2DeviceSource.cpp:111
        error:Resource temporarily unavailable
[NOTICE] /home/azsde/v4l2rtspserver/src/V4L2DeviceSource.cpp:122
This causes v4l2rtspserver to hang indefinitely.

Looking into the code, it seems that if V4L2DeviceSource cannot get the next frame, it will stop the thread in charge of fetching the the frames, not matter what error we have.

Instead of doing so, we check the errno for the EAGAIN value and do not exit if errno equals EAGAIN.