### PR TITLE
Adding libssl-dev as dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Dependencies
 ------------
  - liblivemedia-dev [License LGPL](http://www.live555.com/liveMedia/) > live.2012.01.07 (need StreamReplicator)
  - libv4l2cpp [Unlicense](https://github.com/mpromonet/libv4l2cpp/blob/master/LICENSE)
+ - libssl-dev [Apache License 2.0](https://www.openssl.org/source/apache-license-2.0.txt)
  - liblog4cpp5-dev  [License LGPL](http://log4cpp.sourceforge.net/#license) (optional)
 If liblog4cpp5-dev is not present, a simple log using std::cout is used.
  - libasound2-dev Licence LGPL (optional)


### PR DESCRIPTION
## Description

v4l2rtspserver doesn't make without libssl-dev files

## Related Issue

Not Available

## Motivation and Context

OpenSSL dev files are required to compile this project properly.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
